### PR TITLE
Remove the use of Console.WindowWidth and Console.CursorLeft

### DIFF
--- a/Console/Microsoft.DataTransfer.ConsoleHost/App/Handlers/ErrorHandler.cs
+++ b/Console/Microsoft.DataTransfer.ConsoleHost/App/Handlers/ErrorHandler.cs
@@ -16,8 +16,7 @@ namespace Microsoft.DataTransfer.ConsoleHost.App.Handlers
 
         public int Handle(Exception error)
         {
-            if (Console.CursorLeft != 0)
-                Console.WriteLine();
+            Console.WriteLine();
 
             Console.Write(Resources.CriticalFailurePrefix);
 

--- a/Console/Microsoft.DataTransfer.ConsoleHost/App/Handlers/TransferStatisticsHandler.cs
+++ b/Console/Microsoft.DataTransfer.ConsoleHost/App/Handlers/TransferStatisticsHandler.cs
@@ -35,7 +35,7 @@ namespace Microsoft.DataTransfer.ConsoleHost.App.Handlers
 
         public void PrintResult(ITransferStatisticsSnapshot statistics)
         {
-            Console.Write("\r{0}\r", new String(' ', Console.WindowWidth - 1));
+            Console.WriteLine();
 
             Console.WriteLine(String.Format(CultureInfo.InvariantCulture, Resources.StatisticsResultFormat,
                 statistics.Transferred, statistics.Failed, statistics.ElapsedTime));


### PR DESCRIPTION
Remove the use of Console.WindowWidth and Console.CursorLeft as these cause exceptions when there is no window associated with the process, which is the case when automating dt.exe and setting ProcessStartInfo.UseShellExecute to false for the purpose of redirecting standard output and standard error.
