### PR TITLE
Allow the progress update interval to be configurable

### DIFF
--- a/Console/Microsoft.DataTransfer.ConsoleHost/App.config
+++ b/Console/Microsoft.DataTransfer.ConsoleHost/App.config
@@ -6,7 +6,11 @@
     <section name="dataTransfer.configurationFactories" type="Autofac.Configuration.ComponentsConfigurationSection, Microsoft.DataTransfer.Autofac" />
   </configSections>
 
-  <dataTransfer.sources>
+	<appSettings>
+		<add key="ProgressUpdateIntervalSeconds" value="1" />
+	</appSettings>
+
+	<dataTransfer.sources>
     <add name="DocumentDB" type="Microsoft.DataTransfer.DocumentDb.Source.DocumentDbSourceAdapterFactory, Microsoft.DataTransfer.DocumentDb" />
     <add name="HBase" type="Microsoft.DataTransfer.HBase.Source.HBaseSourceAdapterFactory, Microsoft.DataTransfer.HBase" />
     <add name="DynamoDB" type="Microsoft.DataTransfer.DynamoDb.Source.DynamoDbSourceAdapterFactory, Microsoft.DataTransfer.DynamoDb" />


### PR DESCRIPTION
Allow the progress update interval of OneTimeDataTransferHandler to be externally configurable via an appSetting
