### PR TITLE
fix build error due to wrong library identification

### DIFF
--- a/DocumentDb/Microsoft.DataTransfer.DocumentDb/Microsoft.DataTransfer.DocumentDb.csproj
+++ b/DocumentDb/Microsoft.DataTransfer.DocumentDb/Microsoft.DataTransfer.DocumentDb.csproj
@@ -38,7 +38,7 @@
       <HintPath>..\..\packages\Microsoft.Azure.DocumentDB.1.10.0\lib\net45\Microsoft.Azure.Documents.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Azure.Documents.Client.TransientFaultHandling, Version=1.4.0.0, Culture=neutral, PublicKeyToken=69c3241e6f0468ca, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.Azure.Documents.Client.TransientFaultHandling, Version=1.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.DocumentDB.TransientFaultHandling.1.4.0\lib\net45\Microsoft.Azure.Documents.Client.TransientFaultHandling.dll</HintPath>
       <Private>True</Private>
     </Reference>


### PR DESCRIPTION
`Microsoft.Azure.Documents.Client.TransientFaultHandling` package has wrong `PublicKeyToken` so that build error occured. I fixed the value by removing and reinstalling the nuget package.