### PR TITLE
Fixing exception - Critical error: The maximum number of operations allowed in one batch has been exceeded.

### DIFF
--- a/AzureTable/Microsoft.DataTransfer.AzureTable/Sink/BatchSizeTracker.cs
+++ b/AzureTable/Microsoft.DataTransfer.AzureTable/Sink/BatchSizeTracker.cs
@@ -32,18 +32,24 @@ namespace Microsoft.DataTransfer.AzureTable.Sink.Bulk
         {
             var result = new List<List<TableOperation>>();
             long sum = 0;
+            int maxOperationsLimit = 100;
+            int numberOfOperationsInBatch = 0;
 
             foreach (var op in list)
             {
                 var entity = op.Entity;
                 long docLength = _inputSizeTracker.GetDocumentLength(entity.PartitionKey, entity.RowKey);
 
-                if (result.Count > 0 && (sum += docLength) <= _maxBatchSizeInBytes)
+                if (result.Count > 0 && (sum += docLength) <= _maxBatchSizeInBytes && numberOfOperationsInBatch < maxOperationsLimit)
+                {
                     result[result.Count - 1].Add(op);
+                    numberOfOperationsInBatch++;
+                }
                 else
                 {
                     sum = docLength;
                     result.Add(new List<TableOperation> { op });
+                    numberOfOperationsInBatch = 1;
                 }
             }
 

--- a/AzureTable/Microsoft.DataTransfer.AzureTable/Sink/BatchSizeTracker.cs
+++ b/AzureTable/Microsoft.DataTransfer.AzureTable/Sink/BatchSizeTracker.cs
@@ -32,7 +32,7 @@ namespace Microsoft.DataTransfer.AzureTable.Sink.Bulk
         {
             var result = new List<List<TableOperation>>();
             long sum = 0;
-            int maxOperationsLimit = 100;
+            const int maxOperationsInBatchLimit = 100;
             int numberOfOperationsInBatch = 0;
 
             foreach (var op in list)
@@ -40,7 +40,7 @@ namespace Microsoft.DataTransfer.AzureTable.Sink.Bulk
                 var entity = op.Entity;
                 long docLength = _inputSizeTracker.GetDocumentLength(entity.PartitionKey, entity.RowKey);
 
-                if (result.Count > 0 && (sum += docLength) <= _maxBatchSizeInBytes && numberOfOperationsInBatch < maxOperationsLimit)
+                if (result.Count > 0 && (sum += docLength) <= _maxBatchSizeInBytes && numberOfOperationsInBatch < maxOperationsInBatchLimit)
                 {
                     result[result.Count - 1].Add(op);
                     numberOfOperationsInBatch++;


### PR DESCRIPTION
Fixing issue #38 by limiting number of operations in batch to 100. The reason is that Cosmos DB team decided: "We have decided to keep our behavior consistent with Azure Table storage (with whom we share the same SDK) and limit batches to 100 operations."
Here is the link - please scroll to the second comment of Yaron_Goland (or just search for "100"):
https://docs.microsoft.com/en-us/azure/cosmos-db/tutorial-develop-table-dotnet#insert-a-batch-of-entities.
There is no limit for number of operations in batch in current implementation so exception occurs. I suggest this PR to fix it. Thank you in advance.