### PR TITLE
Updated names from Azure DocumentDB to Azure Cosmos DB

### DIFF
--- a/DocumentDb/Microsoft.DataTransfer.DocumentDb.Wpf/Resources.resx
+++ b/DocumentDb/Microsoft.DataTransfer.DocumentDb.Wpf/Resources.resx
@@ -124,6 +124,6 @@
     <value>Verify Connection</value>
   </data>
   <data name="TestConnectionSuccessMessage" xml:space="preserve">
-    <value>Successfully connected to DocumentDB account</value>
+    <value>Successfully connected to Azure Cosmos DB account</value>
   </data>
 </root>

--- a/Wpf/Microsoft.DataTransfer.WpfHost/App.config
+++ b/Wpf/Microsoft.DataTransfer.WpfHost/App.config
@@ -7,7 +7,7 @@
   </configSections>
 
   <dataTransfer.sources>
-    <add name="DocumentDB" type="Microsoft.DataTransfer.DocumentDb.Source.DocumentDbSourceAdapterFactory, Microsoft.DataTransfer.DocumentDb" />
+    <add name="DocumentDB" displayName="Azure Cosmos DB" type="Microsoft.DataTransfer.DocumentDb.Source.DocumentDbSourceAdapterFactory, Microsoft.DataTransfer.DocumentDb" />
 
     <add name="HBase" type="Microsoft.DataTransfer.HBase.Source.HBaseSourceAdapterFactory, Microsoft.DataTransfer.HBase" />
 
@@ -31,9 +31,9 @@
   <dataTransfer.sinks>
     <add name="JsonFile" displayName="JSON file" type="Microsoft.DataTransfer.JsonFile.Sink.JsonFileSinkAdapterFactory, Microsoft.DataTransfer.JsonFile" />
 
-    <add name="DocumentDBBulk" displayName="DocumentDB - Bulk import (single partition collections)" type="Microsoft.DataTransfer.DocumentDb.Sink.Bulk.DocumentDbBulkSinkAdapterFactory, Microsoft.DataTransfer.DocumentDb" />
+    <add name="DocumentDBBulk" displayName="Azure Cosmos DB - Bulk import (single partition collections)" type="Microsoft.DataTransfer.DocumentDb.Sink.Bulk.DocumentDbBulkSinkAdapterFactory, Microsoft.DataTransfer.DocumentDb" />
 
-    <add name="DocumentDB" displayName="DocumentDB - Sequential record import (partitioned collection)" type="Microsoft.DataTransfer.DocumentDb.Sink.Parallel.DocumentDbParallelSinkAdapterFactory, Microsoft.DataTransfer.DocumentDb" />
+    <add name="DocumentDB" displayName="Azure Cosmos DB - Sequential record import (partitioned collection)" type="Microsoft.DataTransfer.DocumentDb.Sink.Parallel.DocumentDbParallelSinkAdapterFactory, Microsoft.DataTransfer.DocumentDb" />
 
   </dataTransfer.sinks>
 

--- a/Wpf/Microsoft.DataTransfer.WpfHost/App.xaml
+++ b/Wpf/Microsoft.DataTransfer.WpfHost/App.xaml
@@ -19,7 +19,7 @@
       <system:String x:Key="CloseKey">Close</system:String>
 
       <!-- Main window -->
-      <system:String x:Key="MainWindowTitleKey">DocumentDB Data Migration Tool</system:String>
+      <system:String x:Key="MainWindowTitleKey">Azure Cosmos DB Data Migration Tool</system:String>
 
       <!-- Navigation -->
       <system:String x:Key="NavigateToPreviousStepKey">Previous</system:String>
@@ -29,10 +29,10 @@
       <system:String x:Key="StartNewImportKey">New Import</system:String>
 
       <!-- Step: Welcome -->
-      <system:String x:Key="WelcomePageTitleKey">DocumentDB Data Migration Tool</system:String>
+      <system:String x:Key="WelcomePageTitleKey">Azure Cosmos DB Data Migration Tool</system:String>
       <Span x:Key="WelcomePageContentKey">
         <Span>
-          Use the DocumentDB data migration tool to import data to DocumentDB from a variety of sources.
+          Use the Azure Cosmos DB data migration tool to import data to Cosmos from a variety of sources.
           The tool can not only help scope certain source data via queries (e.g. SQL Server, MongoDB),
           but can also transform tabular data (e.g. CSV file, SQL Server) into hierarchical structures.
         </Span>

--- a/Wpf/Microsoft.DataTransfer.WpfHost/App.xaml
+++ b/Wpf/Microsoft.DataTransfer.WpfHost/App.xaml
@@ -32,7 +32,7 @@
       <system:String x:Key="WelcomePageTitleKey">Azure Cosmos DB Data Migration Tool</system:String>
       <Span x:Key="WelcomePageContentKey">
         <Span>
-          Use the Azure Cosmos DB data migration tool to import data to Cosmos from a variety of sources.
+          Use the Azure Cosmos DB data migration tool to import data to Cosmos DB from a variety of sources.
           The tool can not only help scope certain source data via queries (e.g. SQL Server, MongoDB),
           but can also transform tabular data (e.g. CSV file, SQL Server) into hierarchical structures.
         </Span>


### PR DESCRIPTION
I wrote a few labs that used this tool and it was confusing to see the term ``Azure DocumentDB`` throughout the tool. This PR proposes label changes that will update the naming throughout the tool to refer to the service correctly as ``Azure Cosmos DB``.

If you want me to change this to say ``Azure Cosmos DB using the SQL API``, I can do that too.