### PR TITLE
Updated to carry source TimeStamp and empty RowKey scenarios

### DIFF
--- a/AzureTable/Microsoft.DataTransfer.AzureTable/Sink/TableAPIBulkSinkAdapter.cs
+++ b/AzureTable/Microsoft.DataTransfer.AzureTable/Sink/TableAPIBulkSinkAdapter.cs
@@ -168,6 +168,10 @@
             Guard.NotNull("tableEntityDataItem", tableEntityDataItem);
 
             var sourceData = tableEntityDataItem.GetDynamicTableEntity();
+            if (String.IsNullOrWhiteSpace(sourceData.RowKey))
+            {
+                sourceData.RowKey = sourceData.PartitionKey;
+            }
 
             sourceData.Properties.Remove("RowKey");
             sourceData.Properties.Remove("PartitionKey");

--- a/AzureTable/Microsoft.DataTransfer.AzureTable/Source/AzureTableSourceAdapter.cs
+++ b/AzureTable/Microsoft.DataTransfer.AzureTable/Source/AzureTableSourceAdapter.cs
@@ -12,7 +12,8 @@ namespace Microsoft.DataTransfer.AzureTable.Source
     {
         private const string RowKeyFieldName = "RowKey";
         private const string PartitionKeyFieldName = "PartitionKey";
-        private const string TimestampFieldName = "Timestamp";
+        private const string TimestampFieldName = "SourceTimestamp";
+        private const string ETagFieldName = "ETag";
 
         private readonly IAzureTableSourceAdapterInstanceConfiguration configuration;
         private readonly CloudTable table;
@@ -84,6 +85,7 @@ namespace Microsoft.DataTransfer.AzureTable.Source
             {
                 entity.Properties[PartitionKeyFieldName] = new EntityProperty(entity.PartitionKey);
                 entity.Properties[TimestampFieldName] = new EntityProperty(entity.Timestamp);
+                entity.Properties[ETagFieldName] = new EntityProperty(entity.ETag);
             }
 
             entity.Properties[RowKeyFieldName] = new EntityProperty(entity.RowKey);

--- a/AzureTable/Microsoft.DataTransfer.AzureTable/Source/AzureTableSourceAdapter.cs
+++ b/AzureTable/Microsoft.DataTransfer.AzureTable/Source/AzureTableSourceAdapter.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DataTransfer.AzureTable.Source
         private const string RowKeyFieldName = "RowKey";
         private const string PartitionKeyFieldName = "PartitionKey";
         private const string TimestampFieldName = "SourceTimestamp";
-        private const string ETagFieldName = "ETag";
+        private const string ETagFieldName = "SourceETag";
 
         private readonly IAzureTableSourceAdapterInstanceConfiguration configuration;
         private readonly CloudTable table;


### PR DESCRIPTION
Cosmos DB table adapter ignores the source 'Timestamp' column value which comes from the Azure Table storage.  The destination (Cosmos DB Table) automatically creates a 'Timestamp' field and puts the last modified time in it, which is not the same timestamp as exist in the corresponding source (Azure Table storage).  If a user wants to compare the data consistency after the migration, based on timestamp, then the destination needs to carry the source timestamp value.

Also added the source ETag value for the same purpose.

The 3rd change is, Cosmos DB table does not allow empty string value in the 'RowKey' field, which Azure Table storage allows.  So if the source table (Azure Table) contains Empty string in the RowKey field, then this record won't be inserted in Cosmos DB table.  This PR copies the PartitionKey value into RowKey field in this case, to make the migration succeed.