### PR TITLE
update projects to .net 4.5.2, and support new version of cosmosdb SDK

### DIFF
--- a/AzureTable/Microsoft.DataTransfer.AzureTable.FunctionalTests/Microsoft.DataTransfer.AzureTable.FunctionalTests.csproj
+++ b/AzureTable/Microsoft.DataTransfer.AzureTable.FunctionalTests/Microsoft.DataTransfer.AzureTable.FunctionalTests.csproj
@@ -42,8 +42,8 @@
       <HintPath>..\..\packages\Castle.Core.3.3.3\lib\net45\Castle.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Azure.CosmosDB.Table, Version=0.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.CosmosDB.Table.0.9.0-preview\lib\net45\Microsoft.Azure.CosmosDB.Table.dll</HintPath>
+    <Reference Include="Microsoft.Azure.CosmosDB.Table, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.CosmosDB.Table.2.0.0\lib\net45\Microsoft.Azure.CosmosDB.Table.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Documents.Client, Version=1.19.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/AzureTable/Microsoft.DataTransfer.AzureTable.FunctionalTests/Microsoft.DataTransfer.AzureTable.FunctionalTests.csproj
+++ b/AzureTable/Microsoft.DataTransfer.AzureTable.FunctionalTests/Microsoft.DataTransfer.AzureTable.FunctionalTests.csproj
@@ -46,10 +46,6 @@
       <HintPath>..\..\packages\Microsoft.Azure.CosmosDB.Table.2.0.0\lib\net45\Microsoft.Azure.CosmosDB.Table.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Azure.Documents.Client, Version=1.19.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.DocumentDB.1.19.0\lib\net45\Microsoft.Azure.Documents.Client.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Microsoft.Azure.KeyVault.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
       <Private>True</Private>
@@ -68,18 +64,6 @@
     </Reference>
     <Reference Include="Microsoft.Data.Services.Client, Version=5.8.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Data.Services.Client.5.8.3\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.OData.Core, Version=7.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.OData.Core.7.2.0\lib\portable-net45+win8+wpa81\Microsoft.OData.Core.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.OData.Edm, Version=7.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.OData.Edm.7.2.0\lib\portable-net45+win8+wpa81\Microsoft.OData.Edm.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Spatial, Version=7.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Spatial.7.2.0\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Moq, Version=4.5.21.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">

--- a/AzureTable/Microsoft.DataTransfer.AzureTable.FunctionalTests/Microsoft.DataTransfer.AzureTable.FunctionalTests.csproj
+++ b/AzureTable/Microsoft.DataTransfer.AzureTable.FunctionalTests/Microsoft.DataTransfer.AzureTable.FunctionalTests.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.DataTransfer.AzureTable.FunctionalTests</RootNamespace>
     <AssemblyName>Microsoft.DataTransfer.AzureTable.FunctionalTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/AzureTable/Microsoft.DataTransfer.AzureTable.FunctionalTests/packages.config
+++ b/AzureTable/Microsoft.DataTransfer.AzureTable.FunctionalTests/packages.config
@@ -1,16 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Castle.Core" version="3.3.3" targetFramework="net451" />
-  <package id="Microsoft.Azure.CosmosDB.Table" version="0.9.0-preview" targetFramework="net451" />
+  <package id="Microsoft.Azure.CosmosDB.Table" version="2.0.0" targetFramework="net451" />
   <package id="Microsoft.Azure.DocumentDB" version="1.19.0" targetFramework="net451" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net451" />
   <package id="Microsoft.Azure.Storage.Common" version="8.6.0-preview" targetFramework="net451" />
   <package id="Microsoft.Data.Edm" version="5.8.3" targetFramework="net451" />
   <package id="Microsoft.Data.OData" version="5.8.3" targetFramework="net451" />
   <package id="Microsoft.Data.Services.Client" version="5.8.3" targetFramework="net451" />
-  <package id="Microsoft.OData.Core" version="7.2.0" targetFramework="net451" />
-  <package id="Microsoft.OData.Edm" version="7.2.0" targetFramework="net451" />
-  <package id="Microsoft.Spatial" version="7.2.0" targetFramework="net451" />
+  <package id="Microsoft.OData.Core" version="7.5.1" targetFramework="net451" />
+  <package id="Microsoft.OData.Edm" version="7.5.1" targetFramework="net451" />
+  <package id="Microsoft.Spatial" version="7.5.1" targetFramework="net451" />
   <package id="Moq" version="4.5.21" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net451" />
   <package id="System.ComponentModel.EventBasedAsync" version="4.0.11" targetFramework="net451" />

--- a/AzureTable/Microsoft.DataTransfer.AzureTable.FunctionalTests/packages.config
+++ b/AzureTable/Microsoft.DataTransfer.AzureTable.FunctionalTests/packages.config
@@ -1,21 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Castle.Core" version="3.3.3" targetFramework="net451" />
-  <package id="Microsoft.Azure.CosmosDB.Table" version="2.0.0" targetFramework="net451" />
-  <package id="Microsoft.Azure.DocumentDB" version="1.19.0" targetFramework="net451" />
-  <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net451" />
-  <package id="Microsoft.Azure.Storage.Common" version="8.6.0-preview" targetFramework="net451" />
-  <package id="Microsoft.Data.Edm" version="5.8.3" targetFramework="net451" />
-  <package id="Microsoft.Data.OData" version="5.8.3" targetFramework="net451" />
-  <package id="Microsoft.Data.Services.Client" version="5.8.3" targetFramework="net451" />
-  <package id="Microsoft.OData.Core" version="7.5.1" targetFramework="net451" />
-  <package id="Microsoft.OData.Edm" version="7.5.1" targetFramework="net451" />
-  <package id="Microsoft.Spatial" version="7.5.1" targetFramework="net451" />
-  <package id="Moq" version="4.5.21" targetFramework="net451" />
-  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net451" />
-  <package id="System.ComponentModel.EventBasedAsync" version="4.0.11" targetFramework="net451" />
-  <package id="System.Dynamic.Runtime" version="4.0.0" targetFramework="net451" />
-  <package id="System.Linq.Queryable" version="4.0.0" targetFramework="net451" />
-  <package id="System.Net.Requests" version="4.0.11" targetFramework="net451" />
-  <package id="System.Spatial" version="5.8.3" targetFramework="net451" />
+  <package id="Castle.Core" version="3.3.3" targetFramework="net452" />
+  <package id="Microsoft.Azure.CosmosDB.Table" version="2.0.0" targetFramework="net452" />
+  <package id="Microsoft.Azure.DocumentDB" version="1.19.0" targetFramework="net452" />
+  <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net452" />
+  <package id="Microsoft.Azure.Storage.Common" version="8.6.0-preview" targetFramework="net452" />
+  <package id="Microsoft.Data.Edm" version="5.8.3" targetFramework="net452" />
+  <package id="Microsoft.Data.OData" version="5.8.3" targetFramework="net452" />
+  <package id="Microsoft.Data.Services.Client" version="5.8.3" targetFramework="net452" />
+  <package id="Microsoft.OData.Core" version="7.5.1" targetFramework="net452" />
+  <package id="Microsoft.OData.Edm" version="7.5.1" targetFramework="net452" />
+  <package id="Microsoft.Spatial" version="7.5.1" targetFramework="net452" />
+  <package id="Moq" version="4.5.21" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net452" />
+  <package id="System.ComponentModel.EventBasedAsync" version="4.0.11" targetFramework="net452" />
+  <package id="System.Dynamic.Runtime" version="4.0.0" targetFramework="net452" />
+  <package id="System.Linq.Queryable" version="4.0.0" targetFramework="net452" />
+  <package id="System.Net.Requests" version="4.0.11" targetFramework="net452" />
+  <package id="System.Spatial" version="5.8.3" targetFramework="net452" />
 </packages>

--- a/AzureTable/Microsoft.DataTransfer.AzureTable.Wpf/Microsoft.DataTransfer.AzureTable.Wpf.csproj
+++ b/AzureTable/Microsoft.DataTransfer.AzureTable.Wpf/Microsoft.DataTransfer.AzureTable.Wpf.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.DataTransfer.AzureTable.Wpf</RootNamespace>
     <AssemblyName>Microsoft.DataTransfer.AzureTable.Wpf</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>

--- a/AzureTable/Microsoft.DataTransfer.AzureTable/Microsoft.DataTransfer.AzureTable.csproj
+++ b/AzureTable/Microsoft.DataTransfer.AzureTable/Microsoft.DataTransfer.AzureTable.csproj
@@ -37,10 +37,6 @@
       <HintPath>..\..\packages\Microsoft.Azure.CosmosDB.Table.2.0.0\lib\net45\Microsoft.Azure.CosmosDB.Table.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Azure.Documents.Client, Version=1.19.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.DocumentDB.1.19.0\lib\net45\Microsoft.Azure.Documents.Client.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Microsoft.Azure.KeyVault.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
       <Private>True</Private>
@@ -59,22 +55,6 @@
     </Reference>
     <Reference Include="Microsoft.Data.Services.Client, Version=5.8.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Data.Services.Client.5.8.3\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.OData.Core, Version=7.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.OData.Core.7.2.0\lib\portable-net45+win8+wpa81\Microsoft.OData.Core.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.OData.Edm, Version=7.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.OData.Edm.7.2.0\lib\portable-net45+win8+wpa81\Microsoft.OData.Edm.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Spatial, Version=7.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Spatial.7.2.0\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\WindowsAzure.Storage-PremiumTable.0.1.0-preview\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/AzureTable/Microsoft.DataTransfer.AzureTable/Microsoft.DataTransfer.AzureTable.csproj
+++ b/AzureTable/Microsoft.DataTransfer.AzureTable/Microsoft.DataTransfer.AzureTable.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.DataTransfer.AzureTable</RootNamespace>
     <AssemblyName>Microsoft.DataTransfer.AzureTable</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>

--- a/AzureTable/Microsoft.DataTransfer.AzureTable/Microsoft.DataTransfer.AzureTable.csproj
+++ b/AzureTable/Microsoft.DataTransfer.AzureTable/Microsoft.DataTransfer.AzureTable.csproj
@@ -33,8 +33,8 @@
   </PropertyGroup>
   <Import Project="..\..\Solution Items\CommonProperties.proj" />
   <ItemGroup>
-    <Reference Include="Microsoft.Azure.CosmosDB.Table, Version=0.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.CosmosDB.Table.0.9.0-preview\lib\net45\Microsoft.Azure.CosmosDB.Table.dll</HintPath>
+    <Reference Include="Microsoft.Azure.CosmosDB.Table, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.CosmosDB.Table.2.0.0\lib\net45\Microsoft.Azure.CosmosDB.Table.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Documents.Client, Version=1.19.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/AzureTable/Microsoft.DataTransfer.AzureTable/packages.config
+++ b/AzureTable/Microsoft.DataTransfer.AzureTable/packages.config
@@ -1,19 +1,19 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Azure.CosmosDB.Table" version="2.0.0" targetFramework="net451" />
-  <package id="Microsoft.Azure.DocumentDB" version="2.1.0" targetFramework="net451" />
-  <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net451" />
-  <package id="Microsoft.Azure.Storage.Common" version="8.6.0-preview" targetFramework="net451" />
-  <package id="Microsoft.Data.Edm" version="5.8.3" targetFramework="net451" />
-  <package id="Microsoft.Data.OData" version="5.8.3" targetFramework="net451" />
-  <package id="Microsoft.Data.Services.Client" version="5.8.3" targetFramework="net451" />
-  <package id="Microsoft.OData.Core" version="7.5.1" targetFramework="net451" />
-  <package id="Microsoft.OData.Edm" version="7.5.1" targetFramework="net451" />
-  <package id="Microsoft.Spatial" version="7.5.1" targetFramework="net451" />
-  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net451" />
-  <package id="System.ComponentModel.EventBasedAsync" version="4.0.11" targetFramework="net451" />
-  <package id="System.Dynamic.Runtime" version="4.0.0" targetFramework="net451" />
-  <package id="System.Linq.Queryable" version="4.0.0" targetFramework="net451" />
-  <package id="System.Net.Requests" version="4.0.11" targetFramework="net451" />
-  <package id="System.Spatial" version="5.8.3" targetFramework="net451" />
+  <package id="Microsoft.Azure.CosmosDB.Table" version="2.0.0" targetFramework="net452" />
+  <package id="Microsoft.Azure.DocumentDB" version="1.19.0" targetFramework="net452" />
+  <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net452" />
+  <package id="Microsoft.Azure.Storage.Common" version="8.6.0-preview" targetFramework="net452" />
+  <package id="Microsoft.Data.Edm" version="5.8.3" targetFramework="net452" />
+  <package id="Microsoft.Data.OData" version="5.8.3" targetFramework="net452" />
+  <package id="Microsoft.Data.Services.Client" version="5.8.3" targetFramework="net452" />
+  <package id="Microsoft.OData.Core" version="7.5.1" targetFramework="net452" />
+  <package id="Microsoft.OData.Edm" version="7.5.1" targetFramework="net452" />
+  <package id="Microsoft.Spatial" version="7.5.1" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net452" />
+  <package id="System.ComponentModel.EventBasedAsync" version="4.0.11" targetFramework="net452" />
+  <package id="System.Dynamic.Runtime" version="4.0.0" targetFramework="net452" />
+  <package id="System.Linq.Queryable" version="4.0.0" targetFramework="net452" />
+  <package id="System.Net.Requests" version="4.0.11" targetFramework="net452" />
+  <package id="System.Spatial" version="5.8.3" targetFramework="net452" />
 </packages>

--- a/AzureTable/Microsoft.DataTransfer.AzureTable/packages.config
+++ b/AzureTable/Microsoft.DataTransfer.AzureTable/packages.config
@@ -1,20 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Azure.CosmosDB.Table" version="0.9.0-preview" targetFramework="net451" />
-  <package id="Microsoft.Azure.DocumentDB" version="1.19.0" targetFramework="net451" />
+  <package id="Microsoft.Azure.CosmosDB.Table" version="2.0.0" targetFramework="net451" />
+  <package id="Microsoft.Azure.DocumentDB" version="2.1.0" targetFramework="net451" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net451" />
   <package id="Microsoft.Azure.Storage.Common" version="8.6.0-preview" targetFramework="net451" />
   <package id="Microsoft.Data.Edm" version="5.8.3" targetFramework="net451" />
   <package id="Microsoft.Data.OData" version="5.8.3" targetFramework="net451" />
   <package id="Microsoft.Data.Services.Client" version="5.8.3" targetFramework="net451" />
-  <package id="Microsoft.OData.Core" version="7.2.0" targetFramework="net451" />
-  <package id="Microsoft.OData.Edm" version="7.2.0" targetFramework="net451" />
-  <package id="Microsoft.Spatial" version="7.2.0" targetFramework="net451" />
+  <package id="Microsoft.OData.Core" version="7.5.1" targetFramework="net451" />
+  <package id="Microsoft.OData.Edm" version="7.5.1" targetFramework="net451" />
+  <package id="Microsoft.Spatial" version="7.5.1" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net451" />
   <package id="System.ComponentModel.EventBasedAsync" version="4.0.11" targetFramework="net451" />
   <package id="System.Dynamic.Runtime" version="4.0.0" targetFramework="net451" />
   <package id="System.Linq.Queryable" version="4.0.0" targetFramework="net451" />
   <package id="System.Net.Requests" version="4.0.11" targetFramework="net451" />
   <package id="System.Spatial" version="5.8.3" targetFramework="net451" />
-  <package id="WindowsAzure.Storage-PremiumTable" version="0.1.0-preview" targetFramework="net451" />
 </packages>

--- a/Console/Microsoft.DataTransfer.ConsoleHost.DynamicConfiguration/Microsoft.DataTransfer.ConsoleHost.DynamicConfiguration.csproj
+++ b/Console/Microsoft.DataTransfer.ConsoleHost.DynamicConfiguration/Microsoft.DataTransfer.ConsoleHost.DynamicConfiguration.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.DataTransfer.ConsoleHost.DynamicConfiguration</RootNamespace>
     <AssemblyName>Microsoft.DataTransfer.ConsoleHost.DynamicConfiguration</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">

--- a/Console/Microsoft.DataTransfer.ConsoleHost.Extensibility/Microsoft.DataTransfer.ConsoleHost.Extensibility.csproj
+++ b/Console/Microsoft.DataTransfer.ConsoleHost.Extensibility/Microsoft.DataTransfer.ConsoleHost.Extensibility.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.DataTransfer.ConsoleHost.Extensibility</RootNamespace>
     <AssemblyName>Microsoft.DataTransfer.ConsoleHost.Extensibility</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">

--- a/Console/Microsoft.DataTransfer.ConsoleHost.UnitTests/Microsoft.DataTransfer.ConsoleHost.UnitTests.csproj
+++ b/Console/Microsoft.DataTransfer.ConsoleHost.UnitTests/Microsoft.DataTransfer.ConsoleHost.UnitTests.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.DataTransfer.ConsoleHost.UnitTests</RootNamespace>
     <AssemblyName>Microsoft.DataTransfer.ConsoleHost.UnitTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/Console/Microsoft.DataTransfer.ConsoleHost/App.config
+++ b/Console/Microsoft.DataTransfer.ConsoleHost/App.config
@@ -44,10 +44,6 @@
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.Documents.Client" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.19.0.0" newVersion="1.19.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="Microsoft.SqlServer.Types" publicKeyToken="89845dcd8080cc91" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
       </dependentAssembly>

--- a/Console/Microsoft.DataTransfer.ConsoleHost/Microsoft.DataTransfer.ConsoleHost.csproj
+++ b/Console/Microsoft.DataTransfer.ConsoleHost/Microsoft.DataTransfer.ConsoleHost.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.DataTransfer.ConsoleHost</RootNamespace>
     <AssemblyName>dt</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">

--- a/Core/Microsoft.DataTransfer.Core.UnitTests/Microsoft.DataTransfer.Core.UnitTests.csproj
+++ b/Core/Microsoft.DataTransfer.Core.UnitTests/Microsoft.DataTransfer.Core.UnitTests.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.DataTransfer.Core.UnitTests</RootNamespace>
     <AssemblyName>Microsoft.DataTransfer.Core.UnitTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/Core/Microsoft.DataTransfer.Core.UnitTests/packages.config
+++ b/Core/Microsoft.DataTransfer.Core.UnitTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Autofac" version="3.5.2" targetFramework="net45" />
-  <package id="Castle.Core" version="3.3.3" targetFramework="net451" />
-  <package id="Moq" version="4.5.21" targetFramework="net451" />
+  <package id="Castle.Core" version="3.3.3" targetFramework="net452" />
+  <package id="Moq" version="4.5.21" targetFramework="net452" />
 </packages>

--- a/Core/Microsoft.DataTransfer.Core/Microsoft.DataTransfer.Core.csproj
+++ b/Core/Microsoft.DataTransfer.Core/Microsoft.DataTransfer.Core.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.DataTransfer.Core</RootNamespace>
     <AssemblyName>Microsoft.DataTransfer.Core</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/Core/Microsoft.DataTransfer.Extensibility.Basics/Microsoft.DataTransfer.Extensibility.Basics.csproj
+++ b/Core/Microsoft.DataTransfer.Extensibility.Basics/Microsoft.DataTransfer.Extensibility.Basics.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.DataTransfer.Extensibility.Basics</RootNamespace>
     <AssemblyName>Microsoft.DataTransfer.Extensibility.Basics</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">

--- a/Core/Microsoft.DataTransfer.Extensibility/Microsoft.DataTransfer.Extensibility.csproj
+++ b/Core/Microsoft.DataTransfer.Extensibility/Microsoft.DataTransfer.Extensibility.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.DataTransfer.Extensibility</RootNamespace>
     <AssemblyName>Microsoft.DataTransfer.Extensibility</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/Core/Microsoft.DataTransfer.ServiceModel/Microsoft.DataTransfer.ServiceModel.csproj
+++ b/Core/Microsoft.DataTransfer.ServiceModel/Microsoft.DataTransfer.ServiceModel.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.DataTransfer.ServiceModel</RootNamespace>
     <AssemblyName>Microsoft.DataTransfer.ServiceModel</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">

--- a/CsvFile/Microsoft.DataTransfer.CsvFile.FunctionalTests/Microsoft.DataTransfer.CsvFile.FunctionalTests.csproj
+++ b/CsvFile/Microsoft.DataTransfer.CsvFile.FunctionalTests/Microsoft.DataTransfer.CsvFile.FunctionalTests.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.DataTransfer.CsvFile.FunctionalTests</RootNamespace>
     <AssemblyName>Microsoft.DataTransfer.CsvFile.FunctionalTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/CsvFile/Microsoft.DataTransfer.CsvFile.FunctionalTests/packages.config
+++ b/CsvFile/Microsoft.DataTransfer.CsvFile.FunctionalTests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Castle.Core" version="3.3.3" targetFramework="net451" />
-  <package id="Moq" version="4.5.21" targetFramework="net451" />
+  <package id="Castle.Core" version="3.3.3" targetFramework="net452" />
+  <package id="Moq" version="4.5.21" targetFramework="net452" />
 </packages>

--- a/CsvFile/Microsoft.DataTransfer.CsvFile.UnitTests/Microsoft.DataTransfer.CsvFile.UnitTests.csproj
+++ b/CsvFile/Microsoft.DataTransfer.CsvFile.UnitTests/Microsoft.DataTransfer.CsvFile.UnitTests.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.DataTransfer.CsvFile.UnitTests</RootNamespace>
     <AssemblyName>Microsoft.DataTransfer.CsvFile.UnitTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/CsvFile/Microsoft.DataTransfer.CsvFile.Wpf/Microsoft.DataTransfer.CsvFile.Wpf.csproj
+++ b/CsvFile/Microsoft.DataTransfer.CsvFile.Wpf/Microsoft.DataTransfer.CsvFile.Wpf.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.DataTransfer.CsvFile.Wpf</RootNamespace>
     <AssemblyName>Microsoft.DataTransfer.CsvFile.Wpf</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>

--- a/CsvFile/Microsoft.DataTransfer.CsvFile/Microsoft.DataTransfer.CsvFile.csproj
+++ b/CsvFile/Microsoft.DataTransfer.CsvFile/Microsoft.DataTransfer.CsvFile.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.DataTransfer.CsvFile</RootNamespace>
     <AssemblyName>Microsoft.DataTransfer.CsvFile</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">

--- a/DocumentDb/Microsoft.DataTransfer.DocumentDb.FunctionalTests/Microsoft.DataTransfer.DocumentDb.FunctionalTests.csproj
+++ b/DocumentDb/Microsoft.DataTransfer.DocumentDb.FunctionalTests/Microsoft.DataTransfer.DocumentDb.FunctionalTests.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.DataTransfer.DocumentDb.FunctionalTests</RootNamespace>
     <AssemblyName>Microsoft.DataTransfer.DocumentDb.FunctionalTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/DocumentDb/Microsoft.DataTransfer.DocumentDb.FunctionalTests/packages.config
+++ b/DocumentDb/Microsoft.DataTransfer.DocumentDb.FunctionalTests/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Castle.Core" version="3.3.3" targetFramework="net451" />
+  <package id="Castle.Core" version="3.3.3" targetFramework="net452" />
   <package id="EnterpriseLibrary.TransientFaultHandling" version="6.0.1304.0" targetFramework="net45" />
-  <package id="Microsoft.Azure.DocumentDB" version="1.19.0" targetFramework="net451" />
-  <package id="Microsoft.Azure.DocumentDB.TransientFaultHandling" version="1.5.0" targetFramework="net451" />
-  <package id="Moq" version="4.5.21" targetFramework="net451" />
-  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net451" />
-  <package id="System.Spatial" version="5.8.3" targetFramework="net451" />
+  <package id="Microsoft.Azure.DocumentDB" version="1.19.0" targetFramework="net452" />
+  <package id="Microsoft.Azure.DocumentDB.TransientFaultHandling" version="1.5.0" targetFramework="net452" />
+  <package id="Moq" version="4.5.21" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net452" />
+  <package id="System.Spatial" version="5.8.3" targetFramework="net452" />
 </packages>

--- a/DocumentDb/Microsoft.DataTransfer.DocumentDb.UnitTests/Microsoft.DataTransfer.DocumentDb.UnitTests.csproj
+++ b/DocumentDb/Microsoft.DataTransfer.DocumentDb.UnitTests/Microsoft.DataTransfer.DocumentDb.UnitTests.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.DataTransfer.DocumentDb.UnitTests</RootNamespace>
     <AssemblyName>Microsoft.DataTransfer.DocumentDb.UnitTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/DocumentDb/Microsoft.DataTransfer.DocumentDb.UnitTests/packages.config
+++ b/DocumentDb/Microsoft.DataTransfer.DocumentDb.UnitTests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Castle.Core" version="3.3.3" targetFramework="net451" />
-  <package id="Microsoft.Azure.DocumentDB" version="1.19.0" targetFramework="net451" />
-  <package id="Moq" version="4.5.21" targetFramework="net451" />
-  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net451" />
+  <package id="Castle.Core" version="3.3.3" targetFramework="net452" />
+  <package id="Microsoft.Azure.DocumentDB" version="1.19.0" targetFramework="net452" />
+  <package id="Moq" version="4.5.21" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net452" />
 </packages>

--- a/DocumentDb/Microsoft.DataTransfer.DocumentDb.Wpf/Microsoft.DataTransfer.DocumentDb.Wpf.csproj
+++ b/DocumentDb/Microsoft.DataTransfer.DocumentDb.Wpf/Microsoft.DataTransfer.DocumentDb.Wpf.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.DataTransfer.DocumentDb.Wpf</RootNamespace>
     <AssemblyName>Microsoft.DataTransfer.DocumentDb.Wpf</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>

--- a/DocumentDb/Microsoft.DataTransfer.DocumentDb/Microsoft.DataTransfer.DocumentDb.csproj
+++ b/DocumentDb/Microsoft.DataTransfer.DocumentDb/Microsoft.DataTransfer.DocumentDb.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.DataTransfer.DocumentDb</RootNamespace>
     <AssemblyName>Microsoft.DataTransfer.DocumentDb</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>

--- a/DocumentDb/Microsoft.DataTransfer.DocumentDb/packages.config
+++ b/DocumentDb/Microsoft.DataTransfer.DocumentDb/packages.config
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="EnterpriseLibrary.TransientFaultHandling" version="6.0.1304.0" targetFramework="net45" />
-  <package id="Microsoft.Azure.DocumentDB" version="1.19.0" targetFramework="net451" />
-  <package id="Microsoft.Azure.DocumentDB.TransientFaultHandling" version="1.5.0" targetFramework="net451" />
-  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net451" />
-  <package id="System.Spatial" version="5.8.3" targetFramework="net451" />
+  <package id="Microsoft.Azure.DocumentDB" version="1.19.0" targetFramework="net452" />
+  <package id="Microsoft.Azure.DocumentDB.TransientFaultHandling" version="1.5.0" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net452" />
+  <package id="System.Spatial" version="5.8.3" targetFramework="net452" />
 </packages>

--- a/DynamoDb/Microsoft.DataTransfer.DynamoDb.FunctionalTests/Microsoft.DataTransfer.DynamoDb.FunctionalTests.csproj
+++ b/DynamoDb/Microsoft.DataTransfer.DynamoDb.FunctionalTests/Microsoft.DataTransfer.DynamoDb.FunctionalTests.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.DataTransfer.DynamoDb.FunctionalTests</RootNamespace>
     <AssemblyName>Microsoft.DataTransfer.DynamoDb.FunctionalTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/DynamoDb/Microsoft.DataTransfer.DynamoDb.FunctionalTests/packages.config
+++ b/DynamoDb/Microsoft.DataTransfer.DynamoDb.FunctionalTests/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="AWSSDK.Core" version="3.0.0.3-preview" targetFramework="net45" />
   <package id="AWSSDK.DynamoDBv2" version="3.0.0.3-preview" targetFramework="net45" />
-  <package id="Castle.Core" version="3.3.3" targetFramework="net451" />
-  <package id="Moq" version="4.5.21" targetFramework="net451" />
+  <package id="Castle.Core" version="3.3.3" targetFramework="net452" />
+  <package id="Moq" version="4.5.21" targetFramework="net452" />
 </packages>

--- a/DynamoDb/Microsoft.DataTransfer.DynamoDb.Wpf/Microsoft.DataTransfer.DynamoDb.Wpf.csproj
+++ b/DynamoDb/Microsoft.DataTransfer.DynamoDb.Wpf/Microsoft.DataTransfer.DynamoDb.Wpf.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.DataTransfer.DynamoDb.Wpf</RootNamespace>
     <AssemblyName>Microsoft.DataTransfer.DynamoDb.Wpf</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>

--- a/DynamoDb/Microsoft.DataTransfer.DynamoDb/Microsoft.DataTransfer.DynamoDb.csproj
+++ b/DynamoDb/Microsoft.DataTransfer.DynamoDb/Microsoft.DataTransfer.DynamoDb.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.DataTransfer.DynamoDb</RootNamespace>
     <AssemblyName>Microsoft.DataTransfer.DynamoDb</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">

--- a/DynamoDb/Microsoft.DataTransfer.DynamoDb/packages.config
+++ b/DynamoDb/Microsoft.DataTransfer.DynamoDb/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="AWSSDK.Core" version="3.0.0.3-preview" targetFramework="net45" />
   <package id="AWSSDK.DynamoDBv2" version="3.0.0.3-preview" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net451" />
+  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net452" />
 </packages>

--- a/HBase/Microsoft.DataTransfer.HBase.FunctionalTests/Microsoft.DataTransfer.HBase.FunctionalTests.csproj
+++ b/HBase/Microsoft.DataTransfer.HBase.FunctionalTests/Microsoft.DataTransfer.HBase.FunctionalTests.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.DataTransfer.HBase.FunctionalTests</RootNamespace>
     <AssemblyName>Microsoft.DataTransfer.HBase.FunctionalTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/HBase/Microsoft.DataTransfer.HBase.FunctionalTests/packages.config
+++ b/HBase/Microsoft.DataTransfer.HBase.FunctionalTests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Castle.Core" version="3.3.3" targetFramework="net451" />
+  <package id="Castle.Core" version="3.3.3" targetFramework="net452" />
   <package id="Microsoft.HBase.Client" version="0.2.2" targetFramework="net45" />
-  <package id="Moq" version="4.5.21" targetFramework="net451" />
+  <package id="Moq" version="4.5.21" targetFramework="net452" />
   <package id="protobuf-net" version="2.0.0.668" targetFramework="net45" />
 </packages>

--- a/HBase/Microsoft.DataTransfer.HBase.Wpf/Microsoft.DataTransfer.HBase.Wpf.csproj
+++ b/HBase/Microsoft.DataTransfer.HBase.Wpf/Microsoft.DataTransfer.HBase.Wpf.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.DataTransfer.HBase.Wpf</RootNamespace>
     <AssemblyName>Microsoft.DataTransfer.HBase.Wpf</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>

--- a/HBase/Microsoft.DataTransfer.HBase/Microsoft.DataTransfer.HBase.csproj
+++ b/HBase/Microsoft.DataTransfer.HBase/Microsoft.DataTransfer.HBase.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.DataTransfer.HBase</RootNamespace>
     <AssemblyName>Microsoft.DataTransfer.HBase</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">

--- a/HBase/Microsoft.DataTransfer.HBase/packages.config
+++ b/HBase/Microsoft.DataTransfer.HBase/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net451" />
+  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net452" />
 </packages>

--- a/JsonFile/Microsoft.DataTransfer.JsonFile.Wpf/Microsoft.DataTransfer.JsonFile.Wpf.csproj
+++ b/JsonFile/Microsoft.DataTransfer.JsonFile.Wpf/Microsoft.DataTransfer.JsonFile.Wpf.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.DataTransfer.JsonFile.Wpf</RootNamespace>
     <AssemblyName>Microsoft.DataTransfer.JsonFile.Wpf</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>

--- a/JsonFile/Microsoft.DataTransfer.JsonFile/Microsoft.DataTransfer.JsonFile.csproj
+++ b/JsonFile/Microsoft.DataTransfer.JsonFile/Microsoft.DataTransfer.JsonFile.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.DataTransfer.JsonFile</RootNamespace>
     <AssemblyName>Microsoft.DataTransfer.JsonFile</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">

--- a/JsonFile/Microsoft.DataTransfer.JsonFile/packages.config
+++ b/JsonFile/Microsoft.DataTransfer.JsonFile/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net451" />
+  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net452" />
 </packages>

--- a/Microsoft.DataTransfer.FunctionalTests/Microsoft.DataTransfer.FunctionalTests.csproj
+++ b/Microsoft.DataTransfer.FunctionalTests/Microsoft.DataTransfer.FunctionalTests.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.DataTransfer.FunctionalTests</RootNamespace>
     <AssemblyName>Microsoft.DataTransfer.FunctionalTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/Microsoft.DataTransfer.FunctionalTests/packages.config
+++ b/Microsoft.DataTransfer.FunctionalTests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Castle.Core" version="3.3.3" targetFramework="net451" />
-  <package id="Moq" version="4.5.21" targetFramework="net451" />
+  <package id="Castle.Core" version="3.3.3" targetFramework="net452" />
+  <package id="Moq" version="4.5.21" targetFramework="net452" />
 </packages>

--- a/MongoDb/Microsoft.DataTransfer.MongoDb.FunctionalTests/Microsoft.DataTransfer.MongoDb.FunctionalTests.csproj
+++ b/MongoDb/Microsoft.DataTransfer.MongoDb.FunctionalTests/Microsoft.DataTransfer.MongoDb.FunctionalTests.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.DataTransfer.MongoDb.FunctionalTests</RootNamespace>
     <AssemblyName>Microsoft.DataTransfer.MongoDb.FunctionalTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/MongoDb/Microsoft.DataTransfer.MongoDb.FunctionalTests/packages.config
+++ b/MongoDb/Microsoft.DataTransfer.MongoDb.FunctionalTests/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Castle.Core" version="3.3.3" targetFramework="net451" />
-  <package id="MongoDB.Bson" version="2.2.4" targetFramework="net451" />
-  <package id="MongoDB.Driver" version="2.2.4" targetFramework="net451" />
-  <package id="MongoDB.Driver.Core" version="2.2.4" targetFramework="net451" />
-  <package id="Moq" version="4.5.21" targetFramework="net451" />
+  <package id="Castle.Core" version="3.3.3" targetFramework="net452" />
+  <package id="MongoDB.Bson" version="2.2.4" targetFramework="net452" />
+  <package id="MongoDB.Driver" version="2.2.4" targetFramework="net452" />
+  <package id="MongoDB.Driver.Core" version="2.2.4" targetFramework="net452" />
+  <package id="Moq" version="4.5.21" targetFramework="net452" />
 </packages>

--- a/MongoDb/Microsoft.DataTransfer.MongoDb.UnitTests/Microsoft.DataTransfer.MongoDb.UnitTests.csproj
+++ b/MongoDb/Microsoft.DataTransfer.MongoDb.UnitTests/Microsoft.DataTransfer.MongoDb.UnitTests.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.DataTransfer.MongoDb.UnitTests</RootNamespace>
     <AssemblyName>Microsoft.DataTransfer.MongoDb.UnitTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/MongoDb/Microsoft.DataTransfer.MongoDb.UnitTests/packages.config
+++ b/MongoDb/Microsoft.DataTransfer.MongoDb.UnitTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MongoDB.Bson" version="2.2.4" targetFramework="net451" />
-  <package id="MongoDB.Driver" version="2.2.4" targetFramework="net451" />
-  <package id="MongoDB.Driver.Core" version="2.2.4" targetFramework="net451" />
+  <package id="MongoDB.Bson" version="2.2.4" targetFramework="net452" />
+  <package id="MongoDB.Driver" version="2.2.4" targetFramework="net452" />
+  <package id="MongoDB.Driver.Core" version="2.2.4" targetFramework="net452" />
 </packages>

--- a/MongoDb/Microsoft.DataTransfer.MongoDb.Wpf/Microsoft.DataTransfer.MongoDb.Wpf.csproj
+++ b/MongoDb/Microsoft.DataTransfer.MongoDb.Wpf/Microsoft.DataTransfer.MongoDb.Wpf.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.DataTransfer.MongoDb.Wpf</RootNamespace>
     <AssemblyName>Microsoft.DataTransfer.MongoDb.Wpf</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>

--- a/MongoDb/Microsoft.DataTransfer.MongoDb/Microsoft.DataTransfer.MongoDb.csproj
+++ b/MongoDb/Microsoft.DataTransfer.MongoDb/Microsoft.DataTransfer.MongoDb.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.DataTransfer.MongoDb</RootNamespace>
     <AssemblyName>Microsoft.DataTransfer.MongoDb</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">

--- a/MongoDb/Microsoft.DataTransfer.MongoDb/packages.config
+++ b/MongoDb/Microsoft.DataTransfer.MongoDb/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="EnterpriseLibrary.TransientFaultHandling" version="6.0.1304.0" targetFramework="net45" />
-  <package id="MongoDB.Bson" version="2.2.4" targetFramework="net451" />
-  <package id="MongoDB.Driver" version="2.2.4" targetFramework="net451" />
-  <package id="MongoDB.Driver.Core" version="2.2.4" targetFramework="net451" />
+  <package id="MongoDB.Bson" version="2.2.4" targetFramework="net452" />
+  <package id="MongoDB.Driver" version="2.2.4" targetFramework="net452" />
+  <package id="MongoDB.Driver.Core" version="2.2.4" targetFramework="net452" />
 </packages>

--- a/RavenDb/Microsoft.DataTransfer.RavenDb.FunctionalTests/Microsoft.DataTransfer.RavenDb.FunctionalTests.csproj
+++ b/RavenDb/Microsoft.DataTransfer.RavenDb.FunctionalTests/Microsoft.DataTransfer.RavenDb.FunctionalTests.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.DataTransfer.RavenDb.FunctionalTests</RootNamespace>
     <AssemblyName>Microsoft.DataTransfer.RavenDb.FunctionalTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/RavenDb/Microsoft.DataTransfer.RavenDb.FunctionalTests/packages.config
+++ b/RavenDb/Microsoft.DataTransfer.RavenDb.FunctionalTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Castle.Core" version="3.3.3" targetFramework="net451" />
-  <package id="Moq" version="4.5.21" targetFramework="net451" />
+  <package id="Castle.Core" version="3.3.3" targetFramework="net452" />
+  <package id="Moq" version="4.5.21" targetFramework="net452" />
   <package id="RavenDB.Client" version="3.0.3660" targetFramework="net45" />
 </packages>

--- a/RavenDb/Microsoft.DataTransfer.RavenDb.Wpf/Microsoft.DataTransfer.RavenDb.Wpf.csproj
+++ b/RavenDb/Microsoft.DataTransfer.RavenDb.Wpf/Microsoft.DataTransfer.RavenDb.Wpf.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.DataTransfer.RavenDb.Wpf</RootNamespace>
     <AssemblyName>Microsoft.DataTransfer.RavenDb.Wpf</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>

--- a/RavenDb/Microsoft.DataTransfer.RavenDb/Microsoft.DataTransfer.RavenDb.csproj
+++ b/RavenDb/Microsoft.DataTransfer.RavenDb/Microsoft.DataTransfer.RavenDb.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.DataTransfer.RavenDb</RootNamespace>
     <AssemblyName>Microsoft.DataTransfer.RavenDb</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">

--- a/Shared/Microsoft.DataTransfer.Autofac/Microsoft.DataTransfer.Autofac.csproj
+++ b/Shared/Microsoft.DataTransfer.Autofac/Microsoft.DataTransfer.Autofac.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Autofac</RootNamespace>
     <AssemblyName>Microsoft.DataTransfer.Autofac</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">

--- a/Shared/Microsoft.DataTransfer.Basics.Files/Microsoft.DataTransfer.Basics.Files.csproj
+++ b/Shared/Microsoft.DataTransfer.Basics.Files/Microsoft.DataTransfer.Basics.Files.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.DataTransfer.Basics.Files</RootNamespace>
     <AssemblyName>Microsoft.DataTransfer.Basics.Files</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>

--- a/Shared/Microsoft.DataTransfer.Basics.Files/Microsoft.DataTransfer.Basics.Files.csproj
+++ b/Shared/Microsoft.DataTransfer.Basics.Files/Microsoft.DataTransfer.Basics.Files.csproj
@@ -53,18 +53,6 @@
       <HintPath>..\..\packages\Microsoft.Data.Services.Client.5.8.3\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.OData.Core, Version=7.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.OData.Core.7.2.0\lib\portable-net45+win8+wpa81\Microsoft.OData.Core.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.OData.Edm, Version=7.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.OData.Edm.7.2.0\lib\portable-net45+win8+wpa81\Microsoft.OData.Edm.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Spatial, Version=7.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Spatial.7.2.0\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Microsoft.WindowsAzure.Storage, Version=8.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\WindowsAzure.Storage.8.5.0\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
       <Private>True</Private>

--- a/Shared/Microsoft.DataTransfer.Basics.Files/packages.config
+++ b/Shared/Microsoft.DataTransfer.Basics.Files/packages.config
@@ -1,18 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Azure.DocumentDB" version="1.19.0" targetFramework="net451" />
-  <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net451" />
-  <package id="Microsoft.Data.Edm" version="5.8.3" targetFramework="net451" />
-  <package id="Microsoft.Data.OData" version="5.8.3" targetFramework="net451" />
-  <package id="Microsoft.Data.Services.Client" version="5.8.3" targetFramework="net451" />
-  <package id="Microsoft.OData.Core" version="7.2.0" targetFramework="net451" />
-  <package id="Microsoft.OData.Edm" version="7.2.0" targetFramework="net451" />
-  <package id="Microsoft.Spatial" version="7.2.0" targetFramework="net451" />
-  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net451" />
-  <package id="System.ComponentModel.EventBasedAsync" version="4.0.11" targetFramework="net451" />
-  <package id="System.Dynamic.Runtime" version="4.0.0" targetFramework="net451" />
-  <package id="System.Linq.Queryable" version="4.0.0" targetFramework="net451" />
-  <package id="System.Net.Requests" version="4.0.11" targetFramework="net451" />
-  <package id="System.Spatial" version="5.8.3" targetFramework="net451" />
-  <package id="WindowsAzure.Storage" version="8.5.0" targetFramework="net451" />
+  <package id="Microsoft.Azure.DocumentDB" version="1.19.0" targetFramework="net452" />
+  <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net452" />
+  <package id="Microsoft.Data.Edm" version="5.8.3" targetFramework="net452" />
+  <package id="Microsoft.Data.OData" version="5.8.3" targetFramework="net452" />
+  <package id="Microsoft.Data.Services.Client" version="5.8.3" targetFramework="net452" />
+  <package id="Microsoft.OData.Core" version="7.5.1" targetFramework="net452" />
+  <package id="Microsoft.OData.Edm" version="7.5.1" targetFramework="net452" />
+  <package id="Microsoft.Spatial" version="7.5.1" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net452" />
+  <package id="System.ComponentModel.EventBasedAsync" version="4.0.11" targetFramework="net452" />
+  <package id="System.Dynamic.Runtime" version="4.0.0" targetFramework="net452" />
+  <package id="System.Linq.Queryable" version="4.0.0" targetFramework="net452" />
+  <package id="System.Net.Requests" version="4.0.11" targetFramework="net452" />
+  <package id="System.Spatial" version="5.8.3" targetFramework="net452" />
+  <package id="WindowsAzure.Storage" version="8.5.0" targetFramework="net452" />
 </packages>

--- a/Shared/Microsoft.DataTransfer.Basics/Microsoft.DataTransfer.Basics.csproj
+++ b/Shared/Microsoft.DataTransfer.Basics/Microsoft.DataTransfer.Basics.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.DataTransfer.Basics</RootNamespace>
     <AssemblyName>Microsoft.DataTransfer.Basics</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">

--- a/Shared/Microsoft.DataTransfer.JsonNet/Microsoft.DataTransfer.JsonNet.csproj
+++ b/Shared/Microsoft.DataTransfer.JsonNet/Microsoft.DataTransfer.JsonNet.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.DataTransfer.JsonNet</RootNamespace>
     <AssemblyName>Microsoft.DataTransfer.JsonNet</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">

--- a/Shared/Microsoft.DataTransfer.JsonNet/packages.config
+++ b/Shared/Microsoft.DataTransfer.JsonNet/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net451" />
-  <package id="System.Spatial" version="5.8.3" targetFramework="net451" />
+  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net452" />
+  <package id="System.Spatial" version="5.8.3" targetFramework="net452" />
 </packages>

--- a/Shared/Microsoft.DataTransfer.TestsCommon/Microsoft.DataTransfer.TestsCommon.csproj
+++ b/Shared/Microsoft.DataTransfer.TestsCommon/Microsoft.DataTransfer.TestsCommon.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.DataTransfer.TestsCommon</RootNamespace>
     <AssemblyName>Microsoft.DataTransfer.TestsCommon</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">

--- a/Shared/Microsoft.DataTransfer.TestsCommon/packages.config
+++ b/Shared/Microsoft.DataTransfer.TestsCommon/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net451" />
-  <package id="System.Spatial" version="5.8.3" targetFramework="net451" />
+  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net452" />
+  <package id="System.Spatial" version="5.8.3" targetFramework="net452" />
 </packages>

--- a/Sql/Microsoft.DataTransfer.Sql.FunctionalTests/Microsoft.DataTransfer.Sql.FunctionalTests.csproj
+++ b/Sql/Microsoft.DataTransfer.Sql.FunctionalTests/Microsoft.DataTransfer.Sql.FunctionalTests.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.DataTransfer.Sql.FunctionalTests</RootNamespace>
     <AssemblyName>Microsoft.DataTransfer.Sql.FunctionalTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/Sql/Microsoft.DataTransfer.Sql.FunctionalTests/packages.config
+++ b/Sql/Microsoft.DataTransfer.Sql.FunctionalTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Castle.Core" version="3.3.3" targetFramework="net451" />
-  <package id="Moq" version="4.5.21" targetFramework="net451" />
-  <package id="System.Spatial" version="5.8.3" targetFramework="net451" />
+  <package id="Castle.Core" version="3.3.3" targetFramework="net452" />
+  <package id="Moq" version="4.5.21" targetFramework="net452" />
+  <package id="System.Spatial" version="5.8.3" targetFramework="net452" />
 </packages>

--- a/Sql/Microsoft.DataTransfer.Sql.Wpf/Microsoft.DataTransfer.Sql.Wpf.csproj
+++ b/Sql/Microsoft.DataTransfer.Sql.Wpf/Microsoft.DataTransfer.Sql.Wpf.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.DataTransfer.Sql.Wpf</RootNamespace>
     <AssemblyName>Microsoft.DataTransfer.Sql.Wpf</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>

--- a/Sql/Microsoft.DataTransfer.Sql/Microsoft.DataTransfer.Sql.csproj
+++ b/Sql/Microsoft.DataTransfer.Sql/Microsoft.DataTransfer.Sql.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.DataTransfer.Sql</RootNamespace>
     <AssemblyName>Microsoft.DataTransfer.Sql</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">

--- a/Sql/Microsoft.DataTransfer.Sql/packages.config
+++ b/Sql/Microsoft.DataTransfer.Sql/packages.config
@@ -3,5 +3,5 @@
   <package id="EnterpriseLibrary.TransientFaultHandling" version="6.0.1304.0" targetFramework="net45" />
   <package id="EnterpriseLibrary.TransientFaultHandling.Data" version="6.0.1304.1" targetFramework="net45" />
   <package id="Microsoft.SqlServer.Types" version="11.0.2" targetFramework="net45" />
-  <package id="System.Spatial" version="5.8.3" targetFramework="net451" />
+  <package id="System.Spatial" version="5.8.3" targetFramework="net452" />
 </packages>

--- a/Wpf/Microsoft.DataTransfer.WpfHost.Basics/Microsoft.DataTransfer.WpfHost.Basics.csproj
+++ b/Wpf/Microsoft.DataTransfer.WpfHost.Basics/Microsoft.DataTransfer.WpfHost.Basics.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.DataTransfer.WpfHost.Basics</RootNamespace>
     <AssemblyName>Microsoft.DataTransfer.WpfHost.Basics</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">

--- a/Wpf/Microsoft.DataTransfer.WpfHost.Extensibility.Basics/Microsoft.DataTransfer.WpfHost.Extensibility.Basics.csproj
+++ b/Wpf/Microsoft.DataTransfer.WpfHost.Extensibility.Basics/Microsoft.DataTransfer.WpfHost.Extensibility.Basics.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.DataTransfer.WpfHost.Extensibility.Basics</RootNamespace>
     <AssemblyName>Microsoft.DataTransfer.WpfHost.Extensibility.Basics</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">

--- a/Wpf/Microsoft.DataTransfer.WpfHost.Extensibility/Microsoft.DataTransfer.WpfHost.Extensibility.csproj
+++ b/Wpf/Microsoft.DataTransfer.WpfHost.Extensibility/Microsoft.DataTransfer.WpfHost.Extensibility.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.DataTransfer.WpfHost.Extensibility</RootNamespace>
     <AssemblyName>Microsoft.DataTransfer.WpfHost.Extensibility</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">

--- a/Wpf/Microsoft.DataTransfer.WpfHost.ServiceModel/Microsoft.DataTransfer.WpfHost.ServiceModel.csproj
+++ b/Wpf/Microsoft.DataTransfer.WpfHost.ServiceModel/Microsoft.DataTransfer.WpfHost.ServiceModel.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.DataTransfer.WpfHost.ServiceModel</RootNamespace>
     <AssemblyName>Microsoft.DataTransfer.WpfHost.ServiceModel</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">

--- a/Wpf/Microsoft.DataTransfer.WpfHost.UnitTests/Microsoft.DataTransfer.WpfHost.UnitTests.csproj
+++ b/Wpf/Microsoft.DataTransfer.WpfHost.UnitTests/Microsoft.DataTransfer.WpfHost.UnitTests.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.DataTransfer.WpfHost.UnitTests</RootNamespace>
     <AssemblyName>Microsoft.DataTransfer.WpfHost.UnitTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/Wpf/Microsoft.DataTransfer.WpfHost.UnitTests/packages.config
+++ b/Wpf/Microsoft.DataTransfer.WpfHost.UnitTests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Castle.Core" version="3.3.3" targetFramework="net451" />
-  <package id="Moq" version="4.5.21" targetFramework="net451" />
+  <package id="Castle.Core" version="3.3.3" targetFramework="net452" />
+  <package id="Moq" version="4.5.21" targetFramework="net452" />
 </packages>

--- a/Wpf/Microsoft.DataTransfer.WpfHost/App.config
+++ b/Wpf/Microsoft.DataTransfer.WpfHost/App.config
@@ -70,10 +70,6 @@
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.Documents.Client" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.19.0.0" newVersion="1.19.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="Microsoft.SqlServer.Types" publicKeyToken="89845dcd8080cc91" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
       </dependentAssembly>

--- a/Wpf/Microsoft.DataTransfer.WpfHost/Microsoft.DataTransfer.WpfHost.csproj
+++ b/Wpf/Microsoft.DataTransfer.WpfHost/Microsoft.DataTransfer.WpfHost.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.DataTransfer.WpfHost</RootNamespace>
     <AssemblyName>dtui</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>


### PR DESCRIPTION
Update CosmosDB, and dependent packages to newer SDK version. This is to include the newest features developed by the CosmosDB Tables API team.

Simultaneously, these packages require .Net 4.5.2, so upgrade all projects in the codebase to .Net4.5.2