### PR TITLE
Workaround: Trim '\' at the end of connection string for cosmos tables/azure tables api's

### DIFF
--- a/AzureTable/Microsoft.DataTransfer.AzureTable/Sink/TableAPIBulkSinkAdapterFactory.cs
+++ b/AzureTable/Microsoft.DataTransfer.AzureTable/Sink/TableAPIBulkSinkAdapterFactory.cs
@@ -56,6 +56,9 @@ namespace Microsoft.DataTransfer.TableAPI.Sink.Bulk
                 batchSize = configuration.MaxBatchSize.Value;
             }
 
+            if (configuration.ConnectionString.EndsWith("/"))
+                configuration.ConnectionString.TrimEnd('/');
+
             var sink = new TableAPIBulkSinkAdapter(configuration.ConnectionString, 
                             configuration.TableName, configuration.Overwrite, 
                             maxInputBufferSizeInBytes, throughput, batchSize);

--- a/AzureTable/Microsoft.DataTransfer.AzureTable/Source/AzureTableSourceAdapter.cs
+++ b/AzureTable/Microsoft.DataTransfer.AzureTable/Source/AzureTableSourceAdapter.cs
@@ -28,7 +28,7 @@ namespace Microsoft.DataTransfer.AzureTable.Source
 
             string connectionString = System.Text.RegularExpressions.Regex.Replace(
                 configuration.ConnectionString, @"(TableEndpoint=https://)(.*\.)(documents)(\.azure\.com)",
-                m => m.Groups[1].Value + m.Groups[2].Value + "table.cosmosdb" + m.Groups[4].Value);
+                m => m.Groups[1].Value + m.Groups[2].Value + "table.cosmosdb" + m.Groups[4].Value).TrimEnd('/');
 
             var client = CloudStorageAccount.Parse(connectionString).CreateCloudTableClient();
 


### PR DESCRIPTION
There is a use case where a '/' at the end of the connection string, which is sometimes common when copying directly from the azure portal causes the endpoint to not resolve. This change is attempting to remove the '/' character from the end of the connection string so this behavior does not result in errors.