### PR TITLE
Fix Document client

### DIFF
--- a/DocumentDb/Microsoft.DataTransfer.DocumentDb.FunctionalTests/DocumentDbHelper.cs
+++ b/DocumentDb/Microsoft.DataTransfer.DocumentDb.FunctionalTests/DocumentDbHelper.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.Azure.Documents;
 using Microsoft.Azure.Documents.Client;
-using Microsoft.Azure.Documents.Client.TransientFaultHandling;
 using Microsoft.DataTransfer.DocumentDb.Client;
 using Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -73,10 +72,9 @@ namespace Microsoft.DataTransfer.DocumentDb.FunctionalTests
             }
         }
 
-        private static IReliableReadWriteDocumentClient CreateClient(IDocumentDbConnectionSettings connectionSettings)
+        private static DocumentClient CreateClient(IDocumentDbConnectionSettings connectionSettings)
         {
-            return new DocumentClient(new Uri(connectionSettings.AccountEndpoint), connectionSettings.AccountKey)
-                .AsReliable(new FixedInterval(10, TimeSpan.FromSeconds(1)));
+            return new DocumentClient(new Uri(connectionSettings.AccountEndpoint), connectionSettings.AccountKey);
         }
     }
 }

--- a/DocumentDb/Microsoft.DataTransfer.DocumentDb.FunctionalTests/Microsoft.DataTransfer.DocumentDb.FunctionalTests.csproj
+++ b/DocumentDb/Microsoft.DataTransfer.DocumentDb.FunctionalTests/Microsoft.DataTransfer.DocumentDb.FunctionalTests.csproj
@@ -45,10 +45,6 @@
     <Reference Include="Microsoft.Azure.Documents.Client, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.DocumentDB.2.2.1\lib\net45\Microsoft.Azure.Documents.Client.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.Documents.Client.TransientFaultHandling, Version=1.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.DocumentDB.TransientFaultHandling.1.5.0\lib\net45\Microsoft.Azure.Documents.Client.TransientFaultHandling.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\EnterpriseLibrary.TransientFaultHandling.6.0.1304.0\lib\portable-net45+win+wp8\Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.dll</HintPath>

--- a/DocumentDb/Microsoft.DataTransfer.DocumentDb.FunctionalTests/packages.config
+++ b/DocumentDb/Microsoft.DataTransfer.DocumentDb.FunctionalTests/packages.config
@@ -3,7 +3,6 @@
   <package id="Castle.Core" version="3.3.3" targetFramework="net452" />
   <package id="EnterpriseLibrary.TransientFaultHandling" version="6.0.1304.0" targetFramework="net45" />
   <package id="Microsoft.Azure.DocumentDB" version="2.2.1" targetFramework="net452" />
-  <package id="Microsoft.Azure.DocumentDB.TransientFaultHandling" version="1.5.0" targetFramework="net452" />
   <package id="Moq" version="4.5.21" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net452" />
   <package id="System.Net.Http" version="4.3.4" targetFramework="net452" />

--- a/DocumentDb/Microsoft.DataTransfer.DocumentDb/Client/DocumentDbClient.cs
+++ b/DocumentDb/Microsoft.DataTransfer.DocumentDb/Client/DocumentDbClient.cs
@@ -94,7 +94,7 @@ namespace Microsoft.DataTransfer.DocumentDb.Client
             Guard.NotEmpty("collectionLink", collectionLink);
             Guard.NotNull("document", document);
 
-            return client.CreateDocumentAsync(collectionLink, document, null,
+            return client.CreateDocumentAsync(collectionLink, document,
                 disableAutomaticIdGeneration: disableAutomaticIdGeneration);
         }
 
@@ -138,9 +138,6 @@ namespace Microsoft.DataTransfer.DocumentDb.Client
             var matchingCollections = await GetMatchingCollections(database, collectionNamePattern, cancellation);
             if (matchingCollections == null || !matchingCollections.Any())
                 return EmptyAsyncEnumerator<IReadOnlyDictionary<string, object>>.Instance;
-
-            // Use SDK to query multiple collections, client will not be thread-safe
-            //client.UnderlyingClient.PartitionResolvers[database.SelfLink] = new FairPartitionResolver(matchingCollections);
 
             var feedOptions = new FeedOptions
             {

--- a/DocumentDb/Microsoft.DataTransfer.DocumentDb/Client/DocumentDbClient.cs
+++ b/DocumentDb/Microsoft.DataTransfer.DocumentDb/Client/DocumentDbClient.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.Azure.Documents;
 using Microsoft.Azure.Documents.Client;
-using Microsoft.Azure.Documents.Client.TransientFaultHandling;
 using Microsoft.Azure.Documents.Linq;
 using Microsoft.DataTransfer.Basics;
 using Microsoft.DataTransfer.DocumentDb.Client.Enumeration;
@@ -19,10 +18,10 @@ namespace Microsoft.DataTransfer.DocumentDb.Client
 {
     sealed class DocumentDbClient : IDocumentDbWriteClient, IDocumentDbReadClient
     {
-        private IReliableReadWriteDocumentClient client;
+        private DocumentClient client;
         private string databaseName;
 
-        public DocumentDbClient(IReliableReadWriteDocumentClient client, string databaseName)
+        public DocumentDbClient(DocumentClient client, string databaseName)
         {
             Guard.NotNull("client", client);
             Guard.NotEmpty("databaseName", databaseName);
@@ -95,7 +94,7 @@ namespace Microsoft.DataTransfer.DocumentDb.Client
             Guard.NotEmpty("collectionLink", collectionLink);
             Guard.NotNull("document", document);
 
-            return client.CreateDocumentAsync(collectionLink, document,
+            return client.CreateDocumentAsync(collectionLink, document, null,
                 disableAutomaticIdGeneration: disableAutomaticIdGeneration);
         }
 
@@ -141,7 +140,7 @@ namespace Microsoft.DataTransfer.DocumentDb.Client
                 return EmptyAsyncEnumerator<IReadOnlyDictionary<string, object>>.Instance;
 
             // Use SDK to query multiple collections, client will not be thread-safe
-            client.UnderlyingClient.PartitionResolvers[database.SelfLink] = new FairPartitionResolver(matchingCollections);
+            //client.UnderlyingClient.PartitionResolvers[database.SelfLink] = new FairPartitionResolver(matchingCollections);
 
             var feedOptions = new FeedOptions
             {

--- a/DocumentDb/Microsoft.DataTransfer.DocumentDb/Microsoft.DataTransfer.DocumentDb.csproj
+++ b/DocumentDb/Microsoft.DataTransfer.DocumentDb/Microsoft.DataTransfer.DocumentDb.csproj
@@ -37,10 +37,6 @@
     <Reference Include="Microsoft.Azure.Documents.Client, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.DocumentDB.2.2.1\lib\net45\Microsoft.Azure.Documents.Client.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.Documents.Client.TransientFaultHandling, Version=1.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.DocumentDB.TransientFaultHandling.1.5.0\lib\net45\Microsoft.Azure.Documents.Client.TransientFaultHandling.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\EnterpriseLibrary.TransientFaultHandling.6.0.1304.0\lib\portable-net45+win+wp8\Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.dll</HintPath>

--- a/DocumentDb/Microsoft.DataTransfer.DocumentDb/Shared/DocumentDbAdapterFactoryBase.cs
+++ b/DocumentDb/Microsoft.DataTransfer.DocumentDb/Shared/DocumentDbAdapterFactoryBase.cs
@@ -26,15 +26,8 @@ namespace Microsoft.DataTransfer.DocumentDb.Shared
 
             var connectionSettings = ParseConnectionString(configuration.ConnectionString);
             return new DocumentDbClient(
-                CreateRawClient(connectionSettings, configuration.ConnectionMode, context, isShardedImport, maxConnectionLimit, configuration.Retries, configuration.RetryInterval)
-                    //.AsReliable(new FixedInterval(
-                    //    null,
-                    //    GetValueOrDefault(configuration.Retries, Defaults.Current.NumberOfRetries, Errors.InvalidNumberOfRetries),
-                    //    GetValueOrDefault(configuration.RetryInterval, Defaults.Current.RetryInterval, Errors.InvalidRetryInterval),
-                    //    false)),
-                ,connectionSettings.Database
-            );
-            //throttlingRetries - 
+                CreateRawClient(connectionSettings, configuration.ConnectionMode, context, isShardedImport, maxConnectionLimit, configuration.Retries, configuration.RetryInterval),
+                connectionSettings.Database);
         }
 
         private static DocumentClient CreateRawClient(IDocumentDbConnectionSettings connectionSettings, DocumentDbConnectionMode? connectionMode, IDataTransferContext context,

--- a/DocumentDb/Microsoft.DataTransfer.DocumentDb/Shared/DocumentDbAdapterFactoryBase.cs
+++ b/DocumentDb/Microsoft.DataTransfer.DocumentDb/Shared/DocumentDbAdapterFactoryBase.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Azure.Documents.Client;
-using Microsoft.Azure.Documents.Client.TransientFaultHandling;
 using Microsoft.DataTransfer.Basics;
 using Microsoft.DataTransfer.DocumentDb.Client;
 using Microsoft.DataTransfer.Extensibility;
@@ -27,29 +26,31 @@ namespace Microsoft.DataTransfer.DocumentDb.Shared
 
             var connectionSettings = ParseConnectionString(configuration.ConnectionString);
             return new DocumentDbClient(
-                CreateRawClient(connectionSettings, configuration.ConnectionMode, context, isShardedImport, maxConnectionLimit)
-                    .AsReliable(new FixedInterval(
-                        null,
-                        GetValueOrDefault(configuration.Retries, Defaults.Current.NumberOfRetries, Errors.InvalidNumberOfRetries),
-                        GetValueOrDefault(configuration.RetryInterval, Defaults.Current.RetryInterval, Errors.InvalidRetryInterval),
-                        false)),
-                connectionSettings.Database
+                CreateRawClient(connectionSettings, configuration.ConnectionMode, context, isShardedImport, maxConnectionLimit, configuration.Retries, configuration.RetryInterval)
+                    //.AsReliable(new FixedInterval(
+                    //    null,
+                    //    GetValueOrDefault(configuration.Retries, Defaults.Current.NumberOfRetries, Errors.InvalidNumberOfRetries),
+                    //    GetValueOrDefault(configuration.RetryInterval, Defaults.Current.RetryInterval, Errors.InvalidRetryInterval),
+                    //    false)),
+                ,connectionSettings.Database
             );
+            //throttlingRetries - 
         }
 
         private static DocumentClient CreateRawClient(IDocumentDbConnectionSettings connectionSettings, DocumentDbConnectionMode? connectionMode, IDataTransferContext context,
-            bool isShardedImport, int? maxConnectionLimit)
+            bool isShardedImport, int? maxConnectionLimit, int? retries, TimeSpan? retryInterval)
         {
             Guard.NotNull("connectionSettings", connectionSettings);
 
             return new DocumentClient(
                 new Uri(connectionSettings.AccountEndpoint),
                 connectionSettings.AccountKey,
-                CreateConnectionPolicy(connectionMode, context, isShardedImport, maxConnectionLimit)
+                CreateConnectionPolicy(connectionMode, context, isShardedImport, maxConnectionLimit, retries, retryInterval)
             );
         }
 
-        private static ConnectionPolicy CreateConnectionPolicy(DocumentDbConnectionMode? connectionMode, IDataTransferContext context, bool isShardedImport, int? maxConnectionLimit)
+        private static ConnectionPolicy CreateConnectionPolicy(DocumentDbConnectionMode? connectionMode, IDataTransferContext context, bool isShardedImport,
+            int? maxConnectionLimit, int? retries, TimeSpan? retryInterval)
         {
             var entryAssembly = Assembly.GetEntryAssembly();
 
@@ -65,6 +66,13 @@ namespace Microsoft.DataTransfer.DocumentDb.Shared
 
             if (maxConnectionLimit.HasValue)
                 connectionPolicy.MaxConnectionLimit = maxConnectionLimit.Value;
+
+            RetryOptions retryOptions = new RetryOptions();
+            if (retries.HasValue)
+                retryOptions.MaxRetryAttemptsOnThrottledRequests = retries.Value;
+            if (retryInterval.HasValue)
+                retryOptions.MaxRetryWaitTimeInSeconds = retryInterval.Value.Seconds;
+            connectionPolicy.RetryOptions = retryOptions;
 
             return DocumentDbClientHelper.ApplyConnectionMode(connectionPolicy, connectionMode);
         }

--- a/DocumentDb/Microsoft.DataTransfer.DocumentDb/packages.config
+++ b/DocumentDb/Microsoft.DataTransfer.DocumentDb/packages.config
@@ -2,7 +2,6 @@
 <packages>
   <package id="EnterpriseLibrary.TransientFaultHandling" version="6.0.1304.0" targetFramework="net45" />
   <package id="Microsoft.Azure.DocumentDB" version="2.2.1" targetFramework="net452" />
-  <package id="Microsoft.Azure.DocumentDB.TransientFaultHandling" version="1.5.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net452" />
   <package id="System.Net.Http" version="4.3.4" targetFramework="net452" />
   <package id="System.Spatial" version="5.8.3" targetFramework="net452" />


### PR DESCRIPTION
-fixing documentClient code. No functionality change. This is due to move from 1.9.0 -> 2.2.0 version of the DocumentDbSDK. 