### PR TITLE
Jsonreader change for read formatting

### DIFF
--- a/DocumentDb/Microsoft.DataTransfer.DocumentDb/Client/DocumentDbClient.cs
+++ b/DocumentDb/Microsoft.DataTransfer.DocumentDb/Client/DocumentDbClient.cs
@@ -143,7 +143,11 @@ namespace Microsoft.DataTransfer.DocumentDb.Client
             var feedOptions = new FeedOptions
             {
                 EnableCrossPartitionQuery = true,
-                MaxItemCount = -1
+                MaxItemCount = -1,
+                JsonSerializerSettings = new Newtonsoft.Json.JsonSerializerSettings()
+                {
+                    DateParseHandling = Newtonsoft.Json.DateParseHandling.None
+                }
             };
 
             var documentQuery = 

--- a/Solution Items/CommonAssemblyInfo.cs
+++ b/Solution Items/CommonAssemblyInfo.cs
@@ -20,5 +20,5 @@ using System.Runtime.InteropServices;
 
 [assembly: CLSCompliant(false)]
 
-[assembly: AssemblyVersion("1.8.2.0")]
-[assembly: AssemblyFileVersion("1.8.2.0")]
+[assembly: AssemblyVersion("1.8.3.0")]
+[assembly: AssemblyFileVersion("1.8.3.0")]


### PR DESCRIPTION
Jsonreader change for read formatting, DateParseHandling need to use Newtonsoft.Json.DateParseHandling.None to avoid un-intended formatting issue