### PR TITLE
TableAPIBulk: Make sure InputSizeTracker doesn't throw NullRef when projecting properties

### DIFF
--- a/AzureTable/Microsoft.DataTransfer.AzureTable/Sink/InputSizeTracker.cs
+++ b/AzureTable/Microsoft.DataTransfer.AzureTable/Sink/InputSizeTracker.cs
@@ -63,6 +63,13 @@ namespace Microsoft.DataTransfer.TableAPI.Sink.Bulk
 
             foreach (var field in entity.Properties)
             {
+                // unfortunately it is not possible to access IsNull
+                if (field.Value.PropertyAsObject == null)
+                {
+                    // projections can lead null fields being returned
+                    continue;
+                }
+
                 length += field.Key.Length;
 
                 switch (field.Value.PropertyType)


### PR DESCRIPTION
Azure Table can have rows with mixed information. When doing projections out of a row it is possible that columns are null. In such a case the InputSizeTracker throws a null ref exception.

Example

## SomeTable

| OrderId                              | OrderDescription | SomeOtherValue |
|--------------------------------------|------------------|----------------|
| 99b86ac5-a7a0-4824-aaa5-50a33c21dc8d |                  | Foo            |
|                                      | Nice Order       | Bar            |

```
.\dt.exe /ErrorLog:errors.csv /ErrorDetails:All /OverwriteErrorLog:true /s:AzureTable /s.ConnectionString:"redacted" /s.Table:SomeTable /s.InternalFields:All /s.Projection:"OrderId;OrderDescription" /t:TableAPIBulk /t.ConnectionString:"redacted" /t.TableName:SomeTable
```

leads to

```
"9a019e61-9053-4123-a231-ac7500b44d8f","System.NullReferenceException: Object reference not set to an instance of an object.
   at Microsoft.DataTransfer.TableAPI.Sink.Bulk.InputSizeTracker.findLength(Object item) in d:\a\1\s\AzureTable\Microsoft.DataTransfer.AzureTable\Sink\InputSizeTracker.cs:line 68
   at Microsoft.DataTransfer.TableAPI.Sink.Bulk.InputSizeTracker.Add(ITableEntity entity) in d:\a\1\s\AzureTable\Microsoft.DataTransfer.AzureTable\Sink\InputSizeTracker.cs:line 37
   at Microsoft.DataTransfer.TableAPI.Sink.Bulk.TableAPIBulkSinkAdapter.<WriteAsync>d__16.MoveNext() in d:\a\1\s\AzureTable\Microsoft.DataTransfer.AzureTable\Sink\TableAPIBulkSinkAdapter.cs:line 79
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.DataTransfer.Core.Service.DataTransferAction.<TransferDataItem>d__1.MoveNext() in d:\a\1\s\Core\Microsoft.DataTransfer.Core\Service\DataTransferAction.cs:line 79"
"","System.NullReferenceException: Object reference not set to an instance of an object.
   at Microsoft.DataTransfer.TableAPI.Sink.Bulk.InputSizeTracker.findLength(Object item) in d:\a\1\s\AzureTable\Microsoft.DataTransfer.AzureTable\Sink\InputSizeTracker.cs:line 68
   at Microsoft.DataTransfer.TableAPI.Sink.Bulk.InputSizeTracker.Add(ITableEntity entity) in d:\a\1\s\AzureTable\Microsoft.DataTransfer.AzureTable\Sink\InputSizeTracker.cs:line 37
   at Microsoft.DataTransfer.TableAPI.Sink.Bulk.TableAPIBulkSinkAdapter.<WriteAsync>d__16.MoveNext() in d:\a\1\s\AzureTable\Microsoft.DataTransfer.AzureTable\Sink\TableAPIBulkSinkAdapter.cs:line 79
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.DataTransfer.Core.Service.DataTransferAction.<TransferDataItem>d__1.MoveNext() in d:\a\1\s\Core\Microsoft.DataTransfer.Core\Service\DataTransferAction.cs:line 79"
```