### PR TITLE
Added TLS1.2 for Azure Table

### DIFF
--- a/AzureTable/Microsoft.DataTransfer.AzureTable/Source/AzureTableSourceAdapter.cs
+++ b/AzureTable/Microsoft.DataTransfer.AzureTable/Source/AzureTableSourceAdapter.cs
@@ -28,7 +28,7 @@ namespace Microsoft.DataTransfer.AzureTable.Source
         public AzureTableSourceAdapter(IAzureTableSourceAdapterInstanceConfiguration configuration)
         {
             this.configuration = configuration;
-
+            System.Net.ServicePointManager.SecurityProtocol |= System.Net.SecurityProtocolType.Tls12;
             string connectionString = System.Text.RegularExpressions.Regex.Replace(
                 configuration.ConnectionString, @"(TableEndpoint=https://)(.*\.)(documents)(\.azure\.com)",
                 m => m.Groups[1].Value + m.Groups[2].Value + "table.cosmosdb" + m.Groups[4].Value);


### PR DESCRIPTION
Getting error below on default table storage connection.


Critical error: Microsoft.Azure.Storage.StorageException: The remote server returned an error: (400) Bad Request. ---> System.Net.WebException: The remote server returned
 an error: (400) Bad Request.
   at Microsoft.Azure.Storage.Shared.Protocol.HttpResponseParsers.ProcessExpectedStatusCodeNoException[T](HttpStatusCode expectedStatusCode, HttpStatusCode actualStatusCo
de, T retVal, StorageCommandBase`1 cmd, Exception ex)
   at Microsoft.Azure.CosmosDB.Table.TableQuery.<>c__37`1.<QueryImpl>b__37_1(RESTCommand`1 cmd, HttpWebResponse resp, Exception ex, OperationContext ctx) in d:\dbs\sh\csd
b\0913_153609\cmd\1\Product\SDK\Table\.net\Lib\ClassLibraryCommon\Table\TableQueryNonGeneric.cs:line 215
   at Microsoft.Azure.Storage.Core.Executor.Executor.EndGetResponse[T](IAsyncResult getResponseResult)
   --- End of inner exception stack trace ---
   at Microsoft.Azure.Storage.Core.Executor.Executor.EndExecuteAsync[T](IAsyncResult result)
   at Microsoft.Azure.Storage.Core.Util.AsyncExtensions.<>c__DisplayClass2_0`1.<CreateCallback>b__0(IAsyncResult ar)
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.DataTransfer.AzureTable.Source.AzureTableSourceAdapter.<ReadNextAsync>d__11.MoveNext() in d:\a\1\s\AzureTable\Microsoft.DataTransfer.AzureTable\Source\Azu
reTableSourceAdapter.cs:line 61
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at Microsoft.DataTransfer.Core.Service.DataTransferAction.<ExecuteAsync>d__0.MoveNext() in d:\a\1\s\Core\Microsoft.DataTransfer.Core\Service\DataTransferAction.cs:line
 35
Request Information
RequestID:8e80b9d3-6002-006a-088b-693fc1000000
RequestDate:Fri, 25 Jun 2021 06:26:49 GMT
StatusMessage:The TLS version of the connection is not permitted on this storage account.
ErrorCode:TlsVersionNotPermitted
ErrorMessage:The TLS version of the connection is not permitted on this storage account.
RequestId:8e80b9d3-6002-006a-088b-693fc1000000
Time:2021-06-25T06:26:50.1307859Z